### PR TITLE
Se agrega estilos para el listar programas

### DIFF
--- a/relevamiento/static/css/estilo2.css
+++ b/relevamiento/static/css/estilo2.css
@@ -336,7 +336,15 @@ div.content {
 
 }
 
+/*---------------------Para listar programas------*/
+.container-lista-programas{
+  float: inline-block;
+  height: 80%;
+  width: 80vw;
+}
 
-
-
-
+.container-navbar-lp{
+  padding-top: 5%;
+  background-color: rgb(0, 0, 0);
+  width: 15vw;
+}


### PR DESCRIPTION
Se cambia el estilo para el navbar de navegación para la parte de agregar programas, listar y ver los eliminados
(Ver si se deja con los botones arriba de la tabla o se deja el navbar a la izquierda)